### PR TITLE
Make Interface PostDown setting optional in wg.conf template.

### DIFF
--- a/templates/wg.conf
+++ b/templates/wg.conf
@@ -9,7 +9,7 @@ ListenPort = {{ .serverConfig.Interface.ListenPort }}
 PrivateKey = {{ .serverConfig.KeyPair.PrivateKey }}
 {{if .globalSettings.MTU}}MTU = {{ .globalSettings.MTU }}{{end}}
 {{if .serverConfig.Interface.PostUp }}PostUp = {{ .serverConfig.Interface.PostUp }}{{end}}
-PostDown = {{ .serverConfig.Interface.PostDown }}
+{{if .serverConfig.Interface.PostDown }}PostDown = {{ .serverConfig.Interface.PostDown }}{{end}}
 Table = {{ .globalSettings.Table }}
 
 {{range .clientDataList}}{{if eq .Client.Enabled true}}


### PR DESCRIPTION
Tested on b55543f424b4ebffe0080446816fff7b5aa191d1 and verified. 