### PR TITLE
Add global PersistentKeepalive setting to wg.conf template.

### DIFF
--- a/templates/wg.conf
+++ b/templates/wg.conf
@@ -22,4 +22,5 @@ PrivateKey = {{ .serverConfig.KeyPair.PrivateKey }}
 PublicKey = {{ .Client.PublicKey }}
 {{if .Client.PresharedKey }}PresharedKey = {{ .Client.PresharedKey }}
 {{end}}AllowedIPs = {{$first :=true}}{{range .Client.AllocatedIPs }}{{if $first}}{{$first = false}}{{else}},{{end}}{{.}}{{end}}{{range .Client.ExtraAllowedIPs }},{{.}}{{end}}
+{{if $.globalSettings.PersistentKeepalive}}PersistentKeepalive = {{ $.globalSettings.PersistentKeepalive }}{{end}}
 {{end}}{{end}}


### PR DESCRIPTION
If set, this will insert PersistentKeepalive into the server side config Peer sections. PersistentKeepalive is not permissible under Interface sections. Only Peer sections.

Refer to man page or source:

https://git.zx2c4.com/wireguard-tools/tree/src/config.c