### PR TITLE
Update routes.go

### DIFF
--- a/handler/routes.go
+++ b/handler/routes.go
@@ -689,7 +689,7 @@ func DownloadClient(db store.IStore) echo.HandlerFunc {
 
 		// set response header for downloading
 		c.Response().Header().Set(echo.HeaderContentDisposition, fmt.Sprintf("attachment; filename=%s.conf", clientData.Client.Name))
-		return c.Stream(http.StatusOK, "text/plain", reader)
+		return c.Stream(http.StatusOK, "text/conf", reader)
 	}
 }
 


### PR DESCRIPTION
use config file download mime type `txt/conf` to prevent downloaded configs being saved as `<filename>.txt`, instead of wanted `<filename>.conf`. Tested on Android Firefox and Chrome